### PR TITLE
Interpreter - Windows Compatibility - ASCII white space handling

### DIFF
--- a/phase3/src/interpreter.rs
+++ b/phase3/src/interpreter.rs
@@ -156,7 +156,7 @@ fn lex_ir(code: &str) -> Result<Vec<IRTok>, String> {
             }
         }
 
-        ' ' => {
+        ' ' | '\t' | '\r' => {
             i += 1;
         }
 

--- a/phase4/src/interpreter.rs
+++ b/phase4/src/interpreter.rs
@@ -156,7 +156,7 @@ fn lex_ir(code: &str) -> Result<Vec<IRTok>, String> {
             }
         }
 
-        ' ' => {
+        ' ' | '\t' | '\r' => {
             i += 1;
         }
 


### PR DESCRIPTION
Evening,

Some of the students were getting hiccups since on Windows their output was generating \r\n instead of \n.
And the lex_ir treats \r as an invalid symbol.

I figured I'd PR the update in case it helps somebody in the future.

Feel free to decline the PR if it doesn't suit your needs for whatever reason.

Just wanted to give a heads up.

Regards,
JC